### PR TITLE
Minimal, tested and functional docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+  db:
+    image: postgres:latest
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: design_project_b23_db
+    ports:
+      - "5432:5432"
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - "8787:8080"


### PR DESCRIPTION
Reachable at postgres://db:5432, this URI should be then available for
use with at the very least sqlalchemy core. Did some reading, and heroku
does not support docker containers for postgres, as can be seen here:
(https://devcenter.heroku.com/articles/local-development-with-docker-compose#pushing-your-containers-to-heroku), "The python application depends on Postgres and Redis, which you do not push to Heroku. Instead, use Heroku add-ons in production.
